### PR TITLE
fix: make elapsedSeconds millis() rollover safe

### DIFF
--- a/elapsedMillis.h
+++ b/elapsedMillis.h
@@ -80,24 +80,24 @@ public:
 class elapsedSeconds
 {
 private:
-	unsigned long s;
+	unsigned long ms;
 public:
-	elapsedSeconds(void) { s = millis()/1000; }
-	elapsedSeconds(unsigned long val) { s = (millis() / 1000 - val) & 0xFFFFFFFF; }
-	elapsedSeconds(const elapsedSeconds &orig) { s = orig.s; }
-	operator unsigned long () const { return ((millis() / 1000) - s) & 0xFFFFFFFF; }
-	elapsedSeconds & operator = (const elapsedSeconds &rhs) { s = rhs.s; return *this; }
-	elapsedSeconds & operator = (unsigned long val) { s = (millis() / 1000 - val) & 0xFFFFFFFF; return *this; }
-	elapsedSeconds & operator -= (unsigned long val)      { s += val ; return *this; }
-	elapsedSeconds & operator += (unsigned long val)      { s -= val ; return *this; }
-	elapsedSeconds operator - (int val) const           { elapsedSeconds r(*this); r.s += val; return r; }
-	elapsedSeconds operator - (unsigned int val) const  { elapsedSeconds r(*this); r.s += val; return r; }
-	elapsedSeconds operator - (long val) const          { elapsedSeconds r(*this); r.s += val; return r; }
-	elapsedSeconds operator - (unsigned long val) const { elapsedSeconds r(*this); r.s += val; return r; }
-	elapsedSeconds operator + (int val) const           { elapsedSeconds r(*this); r.s -= val; return r; }
-	elapsedSeconds operator + (unsigned int val) const  { elapsedSeconds r(*this); r.s -= val; return r; }
-	elapsedSeconds operator + (long val) const          { elapsedSeconds r(*this); r.s -= val; return r; }
-	elapsedSeconds operator + (unsigned long val) const { elapsedSeconds r(*this); r.s -= val; return r; }
+	elapsedSeconds(void) { ms = millis(); }
+	elapsedSeconds(unsigned long val) { ms = millis() - val * 1000; }
+	elapsedSeconds(const elapsedSeconds &orig) { ms = orig.ms; }
+	operator unsigned long () const { return (millis() - ms) / 1000; }
+	elapsedSeconds & operator = (const elapsedSeconds &rhs) { ms = rhs.ms; return *this; }
+	elapsedSeconds & operator = (unsigned long val)         { ms = millis() - val * 1000; return *this; }
+	elapsedSeconds & operator -= (unsigned long val)    { ms += val * 1000; return *this; }
+	elapsedSeconds & operator += (unsigned long val)    { ms -= val * 1000; return *this; }
+	elapsedSeconds operator - (int val) const           { elapsedSeconds r(*this); r.ms += val * 1000; return r; }
+	elapsedSeconds operator - (unsigned int val) const  { elapsedSeconds r(*this); r.ms += val * 1000; return r; }
+	elapsedSeconds operator - (long val) const          { elapsedSeconds r(*this); r.ms += val * 1000; return r; }
+	elapsedSeconds operator - (unsigned long val) const { elapsedSeconds r(*this); r.ms += val * 1000; return r; }
+	elapsedSeconds operator + (int val) const           { elapsedSeconds r(*this); r.ms -= val * 1000; return r; }
+	elapsedSeconds operator + (unsigned int val) const  { elapsedSeconds r(*this); r.ms -= val * 1000; return r; }
+	elapsedSeconds operator + (long val) const          { elapsedSeconds r(*this); r.ms -= val * 1000; return r; }
+	elapsedSeconds operator + (unsigned long val) const { elapsedSeconds r(*this); r.ms -= val * 1000; return r; }
 };
 
 #endif // __cplusplus

--- a/elapsedMillis.h
+++ b/elapsedMillis.h
@@ -83,11 +83,11 @@ private:
 	unsigned long s;
 public:
 	elapsedSeconds(void) { s = millis()/1000; }
-	elapsedSeconds(unsigned long val) { s = millis()/1000 - val; }
+	elapsedSeconds(unsigned long val) { s = (millis() / 1000 - val) & 0xFFFFFFFF; }
 	elapsedSeconds(const elapsedSeconds &orig) { s = orig.s; }
-	operator unsigned long () const { return millis()/1000 - s; }
+	operator unsigned long () const { return ((millis() / 1000) - s) & 0xFFFFFFFF; }
 	elapsedSeconds & operator = (const elapsedSeconds &rhs) { s = rhs.s; return *this; }
-	elapsedSeconds & operator = (unsigned long val) { s = millis()/1000 - val; return *this; }
+	elapsedSeconds & operator = (unsigned long val) { s = (millis() / 1000 - val) & 0xFFFFFFFF; return *this; }
 	elapsedSeconds & operator -= (unsigned long val)      { s += val ; return *this; }
 	elapsedSeconds & operator += (unsigned long val)      { s -= val ; return *this; }
 	elapsedSeconds operator - (int val) const           { elapsedSeconds r(*this); r.s += val; return r; }

--- a/elapsedMillis.h
+++ b/elapsedMillis.h
@@ -81,23 +81,24 @@ class elapsedSeconds
 {
 private:
 	unsigned long ms;
+    const unsigned long msPerSec = 1000;
 public:
 	elapsedSeconds(void) { ms = millis(); }
-	elapsedSeconds(unsigned long val) { ms = millis() - val * 1000; }
+	elapsedSeconds(unsigned long val) { ms = millis() - val * msPerSec; }
 	elapsedSeconds(const elapsedSeconds &orig) { ms = orig.ms; }
-	operator unsigned long () const { return (millis() - ms) / 1000; }
+	operator unsigned long () const { return (millis() - ms) / msPerSec; }
 	elapsedSeconds & operator = (const elapsedSeconds &rhs) { ms = rhs.ms; return *this; }
-	elapsedSeconds & operator = (unsigned long val)         { ms = millis() - val * 1000; return *this; }
-	elapsedSeconds & operator -= (unsigned long val)    { ms += val * 1000; return *this; }
-	elapsedSeconds & operator += (unsigned long val)    { ms -= val * 1000; return *this; }
-	elapsedSeconds operator - (int val) const           { elapsedSeconds r(*this); r.ms += val * 1000; return r; }
-	elapsedSeconds operator - (unsigned int val) const  { elapsedSeconds r(*this); r.ms += val * 1000; return r; }
-	elapsedSeconds operator - (long val) const          { elapsedSeconds r(*this); r.ms += val * 1000; return r; }
-	elapsedSeconds operator - (unsigned long val) const { elapsedSeconds r(*this); r.ms += val * 1000; return r; }
-	elapsedSeconds operator + (int val) const           { elapsedSeconds r(*this); r.ms -= val * 1000; return r; }
-	elapsedSeconds operator + (unsigned int val) const  { elapsedSeconds r(*this); r.ms -= val * 1000; return r; }
-	elapsedSeconds operator + (long val) const          { elapsedSeconds r(*this); r.ms -= val * 1000; return r; }
-	elapsedSeconds operator + (unsigned long val) const { elapsedSeconds r(*this); r.ms -= val * 1000; return r; }
+	elapsedSeconds & operator = (unsigned long val)         { ms = millis() - val * msPerSec; return *this; }
+	elapsedSeconds & operator -= (unsigned long val)    { ms += val * msPerSec; return *this; }
+	elapsedSeconds & operator += (unsigned long val)    { ms -= val * msPerSec; return *this; }
+	elapsedSeconds operator - (int val) const           { elapsedSeconds r(*this); r.ms += val * msPerSec; return r; }
+	elapsedSeconds operator - (unsigned int val) const  { elapsedSeconds r(*this); r.ms += val * msPerSec; return r; }
+	elapsedSeconds operator - (long val) const          { elapsedSeconds r(*this); r.ms += val * msPerSec; return r; }
+	elapsedSeconds operator - (unsigned long val) const { elapsedSeconds r(*this); r.ms += val * msPerSec; return r; }
+	elapsedSeconds operator + (int val) const           { elapsedSeconds r(*this); r.ms -= val * msPerSec; return r; }
+	elapsedSeconds operator + (unsigned int val) const  { elapsedSeconds r(*this); r.ms -= val * msPerSec; return r; }
+	elapsedSeconds operator + (long val) const          { elapsedSeconds r(*this); r.ms -= val * msPerSec; return r; }
+	elapsedSeconds operator + (unsigned long val) const { elapsedSeconds r(*this); r.ms -= val * msPerSec; return r; }
 };
 
 #endif // __cplusplus


### PR DESCRIPTION
Fixes #16 by using modular arithmetic - edit: which will never complete, so fall back to using ms internally